### PR TITLE
新規目標追加ボタンを追加

### DIFF
--- a/frontend/flutter_app/lib/chat.dart
+++ b/frontend/flutter_app/lib/chat.dart
@@ -50,6 +50,41 @@ class _ChatPageState extends State<ChatPage> {
     }
   }
 
+  /// 新規目標をFirestoreに追加する
+  Future<void> _addObjective(String objective) async {
+    // 現在ログインしているユーザー
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null) {
+      // ログインしていない場合のエラーハンドリング
+      return;
+    }
+
+    try {
+      final objectiveId = _firestore
+          .collection('users')
+          .doc(currentUser.uid)
+          .collection('objectives')
+          .doc()
+          .id;
+      await _firestore
+          .collection('users')
+          .doc(currentUser.uid)
+          .collection('objectives')
+          .doc(objectiveId)
+          .set({
+        'objective': objective,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('目標が追加されました')),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Firestore書き込みエラー: $e')),
+      );
+    }
+  }
+
   /// ログアウト処理
   Future<void> _signOut() async {
     await FirebaseAuth.instance.signOut();
@@ -76,6 +111,7 @@ class _ChatPageState extends State<ChatPage> {
         .snapshots();
 
     return Scaffold(
+      backgroundColor: Colors.grey[200],
       appBar: AppBar(
         title: const Text('Chat'),
         actions: [
@@ -86,94 +122,177 @@ class _ChatPageState extends State<ChatPage> {
         ],
       ),
       drawer: Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: [
-            const DrawerHeader(
-              decoration: BoxDecoration(
-                color: Colors.blue,
-              ),
-              child: Text(
-                'Chat History',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 24,
+        backgroundColor: Colors.white,
+        child: SafeArea(
+          child: ListView(
+            padding: EdgeInsets.zero,
+            children: [
+              SizedBox(
+                height: 150,
+                child: DrawerHeader(
+                  decoration: BoxDecoration(
+                    color: Colors.blue[800],
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(
+                        '目標一覧',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 24,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: ElevatedButton.icon(
+                          onPressed: () {
+                            showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                final TextEditingController
+                                    objectiveController =
+                                    TextEditingController();
+                                return AlertDialog(
+                                  title: const Text('新規目標追加'),
+                                  content: TextField(
+                                    controller: objectiveController,
+                                    decoration: const InputDecoration(
+                                      hintText: '目標を入力してください',
+                                    ),
+                                  ),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                      child: const Text('キャンセル'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () {
+                                        final objective =
+                                            objectiveController.text.trim();
+                                        if (objective.isNotEmpty) {
+                                          _addObjective(objective);
+                                        }
+                                        Navigator.of(context).pop();
+                                      },
+                                      child: const Text('追加'),
+                                    ),
+                                  ],
+                                );
+                              },
+                            );
+                          },
+                          icon: const Icon(Icons.add),
+                          label: const Text('新規目標'),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
+              StreamBuilder<QuerySnapshot>(
+                stream: _firestore
+                    .collection('users')
+                    .doc(currentUser.uid)
+                    .collection('objectives')
+                    .orderBy('createdAt', descending: true)
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final docs = snapshot.data!.docs;
+                  return ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: docs.length,
+                    itemBuilder: (context, index) {
+                      final data = docs[index].data() as Map<String, dynamic>;
+                      final objective = data['objective'] ?? 'No Objective';
+                      return ListTile(
+                        title: Text(objective),
+                        onTap: () {
+                          Navigator.pop(context);
+                          // 目標をタップしたときの処理をここに記述
+                          // そのObjectiveのIDを取得して、それに紐づくchatを表示する
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // メッセージ一覧
+            Expanded(
+              child: StreamBuilder<QuerySnapshot>(
+                stream: messageStream,
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final docs = snapshot.data!.docs;
+                  return ListView.builder(
+                    reverse: true,
+                    itemCount: docs.length,
+                    itemBuilder: (context, index) {
+                      final data = docs[index].data() as Map<String, dynamic>;
+                      final content = data['content'] ?? 'No Message';
+                      final role = data['role'] ?? 'Unknown';
+                      final createdAt =
+                          data['createdAt']?.toDate().toString() ?? 'No Time';
+
+                      return ListTile(
+                        title: Text(content),
+                      );
+                    },
+                  );
+                },
+              ),
             ),
-            ListTile(
-              title: const Text('Chat 1'),
-              onTap: () {
-                Navigator.pop(context);
-                // ダミーデータのチャット履歴を表示
-              },
-            ),
-            ListTile(
-              title: const Text('Chat 2'),
-              onTap: () {
-                Navigator.pop(context);
-                // ダミーデータのチャット履歴を表示
-              },
-            ),
-            ListTile(
-              title: const Text('Chat 3'),
-              onTap: () {
-                Navigator.pop(context);
-                // ダミーデータのチャット履歴を表示
-              },
+            // 入力欄
+            Padding(
+              padding:
+                  const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Container(
+                      height: 60, // 高さを広く設定
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(12), // 角を丸くする
+                        border: Border.all(color: Colors.grey), // 枠線を追加
+                      ),
+                      child: TextField(
+                        controller: _textController,
+                        decoration: const InputDecoration(
+                          hintText: 'Enter message',
+                          border: InputBorder.none, // デフォルトの枠線を削除
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 16), // 内側の余白を設定
+                        ),
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(
+                      Icons.send,
+                      color: Colors.blueAccent,
+                    ),
+                    onPressed: _addMessage,
+                  ),
+                ],
+              ),
             ),
           ],
         ),
-      ),
-      body: Column(
-        children: [
-          // メッセージ一覧
-          Expanded(
-            child: StreamBuilder<QuerySnapshot>(
-              stream: messageStream,
-              builder: (context, snapshot) {
-                if (!snapshot.hasData) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                final docs = snapshot.data!.docs;
-                return ListView.builder(
-                  reverse: true,
-                  itemCount: docs.length,
-                  itemBuilder: (context, index) {
-                    final data = docs[index].data() as Map<String, dynamic>;
-                    final content = data['content'] ?? 'No Message';
-                    final role = data['role'] ?? 'Unknown';
-                    final createdAt =
-                        data['createdAt']?.toDate().toString() ?? 'No Time';
-
-                    return ListTile(
-                      title: Text(content),
-                    );
-                  },
-                );
-              },
-            ),
-          ),
-          // 入力欄
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _textController,
-                    decoration:
-                        const InputDecoration(hintText: 'Enter message'),
-                  ),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.send),
-                  onPressed: _addMessage,
-                ),
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/frontend/flutter_app/lib/main.dart
+++ b/frontend/flutter_app/lib/main.dart
@@ -22,7 +22,15 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Firebase Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+          ),
+        ),
+      ),
       initialRoute: '/',
       routes: {
         '/': (context) => const AuthGate(),


### PR DESCRIPTION
# issue 番号

- #15

# 概要

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

- 新規目標追加ボタンを追加しました。

# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイントです -->

- 新規目標追加ボタン UI の作成
- 新規目標を追加したら、firestore に書き込むロジックの実装
- 追加した目標を Drawer menu に表示する実装
  - firestore の監視も含んでいます

以下、本件とは関係のない対応です
- Drawer menu のヘッダーの高さを固定値に変更(150px)
- チャット入力欄のデザイン調整
- elevatedButton の Theme 設定

## スクリーンショット

![image](https://github.com/user-attachments/assets/61f5d8ab-99ed-4c04-bf0c-b220ccbe034c)

# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->

- 破壊的変更は含んでいません

# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。大きなUI変更は iOS Safari / Android Chrome での確認もすること -->
* [x] 新規目標追加ボタンから目標を追加出来ること
* [x] 追加した目標が firestore に登録されていること


# その他

<!-- レビュアーへのメッセージや一言などあれば -->

- 特になし