### PR TITLE
Firestoreへのチャット応答の保存機能を追加し、DockerfileにGCPプロジェクトIDとリージョンを設定

### DIFF
--- a/backend/src/chatbot/Dockerfile
+++ b/backend/src/chatbot/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.11-slim
 # タイムゾーンを設定
 ENV TZ=Asia/Tokyo
 
+# GCPプロジェクトIDとVertex AIのリージョンを設定
+# PROJECT_IDはご自身のプロジェクトIDに変更してください
+ENV PROJECT_ID=tasktrail-ao
+ENV VERTEX_AI_LOCATION=asia-northeast1
 
 WORKDIR /app
 
@@ -11,4 +15,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"] 
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/src/chatbot/firestore/store.py
+++ b/backend/src/chatbot/firestore/store.py
@@ -1,0 +1,28 @@
+from google.cloud import firestore
+from datetime import datetime
+
+def save_chat_response(response_data: dict) -> None:
+    """
+    generate_response の結果を Firestore に保存する
+
+    Args:
+        response_data: generate_response から返される辞書
+        {
+            "status": "success/error",
+            "response": "生成されたレスポンステキスト",
+            "prompt": "入力されたプロンプト"
+        }
+    """
+    # Firestore クライアントの初期化
+    db = firestore.Client()
+
+    # 保存するデータを作成
+    chat_doc = {
+        "status": response_data["status"],
+        "response": response_data["response"],
+        "prompt": response_data["prompt"],
+        "timestamp": firestore.SERVER_TIMESTAMP
+    }
+
+    # chat_responses コレクションに保存
+    db.collection('chat_responses').add(chat_doc)

--- a/backend/src/chatbot/requirements.txt
+++ b/backend/src/chatbot/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110.0
 uvicorn==0.27.1
 google-cloud-aiplatform>=1.74.0
-pydantic==2.6.3 
+pydantic==2.6.3
 python-dotenv>=1.0.0
+google-cloud-firestore


### PR DESCRIPTION
# issue 番号
firestoreに北村さんのapiのレスポンスを書き込み #5

# テストしたレスポンス
```
url -X POST https://chatbot-api-616604787662.asia-northeast1.run.app/chat \
     -H "Content-Type: application/json" \
     -d '{"prompt": "こんにちは！", "chat_history": []}'
{"status":"success","response":"こんにちは！  私は、質問の回答や、文章の翻訳などを行うことができる、日本語アシスタントのジェミニです。\n\n何かご質問がありましたら、お気軽にお問い合わせください。","prompt":"こんにちは！","error":null}%   
```

# スクリーンショット
![image](https://github.com/user-attachments/assets/c18df659-e9d4-4c68-91cc-ff62c7f20b2f)

# 備考
Dockerファイルに以下の通り、PROJECT_IDを設定する箇所がありますが、ご自身のGCPプロジェクトのプロジェクトIDに変更してください。
```
# PROJECT_IDはご自身のプロジェクトIDに変更してください
ENV PROJECT_ID=tasktrail-ao
```
