### PR TITLE
リージョンを揃える

### DIFF
--- a/backend/src/chatbot/cloudbuild.yaml
+++ b/backend/src/chatbot/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'asia-east1-docker.pkg.dev/$PROJECT_ID/chatbot-api-repo/chatbot-api:$COMMIT_SHA', '.']
+    args: ['build', '-t', 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/chatbot-api-repo/chatbot-api:$COMMIT_SHA', '.']
 
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
バックエンドのcloudbuild.yamlの以下の部分においてリージョンの不一致があったため、northeast1に統一しました。
```
  # Build the container image
  - name: 'gcr.io/cloud-builders/docker'
    args: ['build', '-t', 'asia-east1-docker.pkg.dev/$PROJECT_ID/chatbot-api-repo/chatbot-api:$COMMIT_SHA', '.']

  # Push the container image to Artifact Registry
  - name: 'gcr.io/cloud-builders/docker'
    args: ['push', 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/chatbot-api-repo/chatbot-api:$COMMIT_SHA']
```