### PR TITLE
【フロント】初回入力フォームを作った

### DIFF
--- a/frontend/flutter_app/lib/view/chat_input_widget.dart
+++ b/frontend/flutter_app/lib/view/chat_input_widget.dart
@@ -1,0 +1,54 @@
+// lib/view/chat_page.dart
+import 'package:flutter/material.dart';
+import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
+
+class ChatInputArea extends StatelessWidget {
+  final ChatViewModel chatViewModel;
+
+  const ChatInputArea({
+    Key? key,
+    required this.chatViewModel,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: Container(
+              height: 60, // 高さを広く設定
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12), // 角を丸くする
+                border: Border.all(color: Colors.grey), // 枠線を追加
+              ),
+              child: TextField(
+                controller: chatViewModel.textController,
+                decoration: const InputDecoration(
+                  hintText: 'Enter message',
+                  border: InputBorder.none, // デフォルトの枠線を削除
+                  contentPadding: EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 16,
+                  ), // 内側の余白を設定
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.send,
+              color: Colors.blueAccent,
+            ),
+            onPressed: () {
+              // メッセージ送信
+              chatViewModel.addMessage('tekitotekito', context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/view/chat_page.dart
+++ b/frontend/flutter_app/lib/view/chat_page.dart
@@ -127,48 +127,7 @@ class ChatPage extends ConsumerWidget {
                         );
                       } else {
                         // すでにチャットが存在する場合 -> 普通のメッセージ送信欄のみ
-                        return Padding(
-                          padding: const EdgeInsets.only(
-                              right: 16.0, left: 16.0, bottom: 32.0),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Container(
-                                  height: 60, // 高さを広く
-                                  decoration: BoxDecoration(
-                                    color: Colors.white,
-                                    borderRadius: BorderRadius.circular(12),
-                                    border: Border.all(color: Colors.grey),
-                                  ),
-                                  child: TextField(
-                                    controller: chatViewModel.textController,
-                                    decoration: const InputDecoration(
-                                      hintText: 'Enter message',
-                                      border: InputBorder.none,
-                                      contentPadding: EdgeInsets.symmetric(
-                                        horizontal: 16,
-                                        vertical: 16,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.send,
-                                  color: Colors.blueAccent,
-                                ),
-                                onPressed: () {
-                                  // 通常のメッセージ送信
-                                  chatViewModel.addMessage(
-                                    'tekitotekito',
-                                    context,
-                                  );
-                                },
-                              ),
-                            ],
-                          ),
-                        );
+                        return SizedBox();
                       }
                     },
                   )

--- a/frontend/flutter_app/lib/view/chat_page.dart
+++ b/frontend/flutter_app/lib/view/chat_page.dart
@@ -7,6 +7,7 @@ import 'package:hackathon_test1/view/common/add_goal_button.dart';
 import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
 import 'package:hackathon_test1/viewmodel/goal_viewmodel.dart';
 
+import 'chat_input_widget.dart';
 import 'first_input_widget.dart';
 
 class ChatPage extends ConsumerWidget {
@@ -145,57 +146,16 @@ class ChatPage extends ConsumerWidget {
           StreamBuilder<QuerySnapshot>(
             stream: chatStream,
             builder: (context, snapshot) {
-              // まだデータがない（ロード中）の場合は空表示にしておく
               if (!snapshot.hasData) {
                 return const SizedBox();
               }
 
-              // ドキュメントを取得
               final docs = snapshot.data!.docs;
-              // チャットのドキュメントが空ではないか？
               final notEmpty = docs.isNotEmpty;
-              // 目標が選択されているか？
               final hasGoalId = chatViewModel.selectedGoalId != null;
 
-              // 両方の条件を満たす場合のみ入力欄を表示、それ以外は SizedBox() を返す
               if (hasGoalId && notEmpty) {
-                return Padding(
-                  padding: const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Container(
-                          height: 60, // 高さを広く設定
-                          decoration: BoxDecoration(
-                            color: Colors.white,
-                            borderRadius: BorderRadius.circular(12), // 角を丸くする
-                            border: Border.all(color: Colors.grey), // 枠線を追加
-                          ),
-                          child: TextField(
-                            controller: chatViewModel.textController,
-                            decoration: const InputDecoration(
-                              hintText: 'Enter message',
-                              border: InputBorder.none,
-                              contentPadding: EdgeInsets.symmetric(
-                                horizontal: 16,
-                                vertical: 16,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      IconButton(
-                        icon: const Icon(
-                          Icons.send,
-                          color: Colors.blueAccent,
-                        ),
-                        onPressed: () {
-                          chatViewModel.addMessage('tekitotekito', context);
-                        },
-                      ),
-                    ],
-                  ),
-                );
+                return ChatInputArea(chatViewModel: chatViewModel);
               } else {
                 return const SizedBox();
               }

--- a/frontend/flutter_app/lib/view/chat_page.dart
+++ b/frontend/flutter_app/lib/view/chat_page.dart
@@ -25,8 +25,7 @@ class ChatPage extends ConsumerWidget {
     }
     final userId = user.uid;
 
-    final chatStream =
-        chatViewModel.getChatStream(user.uid, chatViewModel.selectedGoalId);
+    final chatStream = chatViewModel.getChatStream(user.uid, chatViewModel.selectedGoalId);
 
     // 目標一覧のStream
     final goalStream = chatViewModel.getGoalStream(user.uid);
@@ -142,12 +141,26 @@ class ChatPage extends ConsumerWidget {
                     ),
                   ),
           ),
-          // 入力欄
+          // ★★入力欄
+          StreamBuilder<QuerySnapshot>(
+            stream: chatStream,
+            builder: (context, snapshot) {
+              // まだデータがない（ロード中）の場合は空表示にしておく
+              if (!snapshot.hasData) {
+                return const SizedBox();
+              }
 
-          chatViewModel.selectedGoalId != null
-              ? Padding(
-                  padding: const EdgeInsets.only(
-                      right: 16.0, left: 16.0, bottom: 32.0),
+              // ドキュメントを取得
+              final docs = snapshot.data!.docs;
+              // チャットのドキュメントが空ではないか？
+              final notEmpty = docs.isNotEmpty;
+              // 目標が選択されているか？
+              final hasGoalId = chatViewModel.selectedGoalId != null;
+
+              // 両方の条件を満たす場合のみ入力欄を表示、それ以外は SizedBox() を返す
+              if (hasGoalId && notEmpty) {
+                return Padding(
+                  padding: const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0),
                   child: Row(
                     children: [
                       Expanded(
@@ -162,9 +175,11 @@ class ChatPage extends ConsumerWidget {
                             controller: chatViewModel.textController,
                             decoration: const InputDecoration(
                               hintText: 'Enter message',
-                              border: InputBorder.none, // デフォルトの枠線を削除
+                              border: InputBorder.none,
                               contentPadding: EdgeInsets.symmetric(
-                                  horizontal: 16, vertical: 16), // 内側の余白を設定
+                                horizontal: 16,
+                                vertical: 16,
+                              ),
                             ),
                           ),
                         ),
@@ -180,8 +195,12 @@ class ChatPage extends ConsumerWidget {
                       ),
                     ],
                   ),
-                )
-              : const SizedBox(),
+                );
+              } else {
+                return const SizedBox();
+              }
+            },
+          ),
         ],
       ),
     );

--- a/frontend/flutter_app/lib/view/first_input_widget.dart
+++ b/frontend/flutter_app/lib/view/first_input_widget.dart
@@ -85,7 +85,7 @@ class _FirstInputWidgetState extends State<FirstInputWidget> {
             child: TextField(
               controller: _messageController,
               decoration: const InputDecoration(
-                hintText: 'Enter message',
+                hintText: '目標を入力してください',
                 border: InputBorder.none,
                 contentPadding: EdgeInsets.symmetric(
                   horizontal: 16,

--- a/frontend/flutter_app/lib/view/first_input_widget.dart
+++ b/frontend/flutter_app/lib/view/first_input_widget.dart
@@ -1,0 +1,160 @@
+// lib/view/chat_page.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hackathon_test1/view/common/add_goal_button.dart';
+import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
+import 'package:hackathon_test1/viewmodel/goal_viewmodel.dart';
+
+class FirstInputWidget extends StatefulWidget {
+  final ChatViewModel chatViewModel;
+  final String userId;
+  final String goalId;
+
+  const FirstInputWidget({
+    Key? key,
+    required this.chatViewModel,
+    required this.userId,
+    required this.goalId,
+  }) : super(key: key);
+
+  @override
+  State<FirstInputWidget> createState() => _FirstInputWidgetState();
+}
+
+class _FirstInputWidgetState extends State<FirstInputWidget> {
+  final TextEditingController _deadlineController = TextEditingController();
+  final TextEditingController _weeklyHoursController = TextEditingController();
+  final TextEditingController _messageController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding:
+      const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0, top: 8.0),
+      // 下に寄せるために、上に大きな余白をとらないようにしています
+      child: Column(
+        mainAxisSize: MainAxisSize.min, // 必要最小限の高さに
+        children: [
+          // 期日 (カレンダーPicker)
+          TextField(
+            controller: _deadlineController,
+            decoration: const InputDecoration(
+              labelText: '期日を選択',
+              border: OutlineInputBorder(),
+              suffixIcon: Icon(Icons.calendar_today),
+            ),
+            readOnly: true,
+            onTap: () async {
+              final pickedDate = await showDatePicker(
+                context: context,
+                initialDate: DateTime.now(),
+                firstDate: DateTime(2020),
+                lastDate: DateTime(2100),
+              );
+              if (pickedDate != null) {
+                setState(() {
+                  _deadlineController.text =
+                  "${pickedDate.year}/${pickedDate.month}/${pickedDate.day}";
+                });
+              }
+            },
+          ),
+          const SizedBox(height: 8),
+
+          // 週あたり作業時間
+          TextField(
+            controller: _weeklyHoursController,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(
+              labelText: '週あたり作業時間(時間)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 8),
+
+          // メッセージ入力
+          Container(
+            height: 60,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: Colors.grey),
+            ),
+            child: TextField(
+              controller: _messageController,
+              decoration: const InputDecoration(
+                hintText: 'Enter message',
+                border: InputBorder.none,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 16,
+                ),
+              ),
+            ),
+          ),
+
+          // 送信ボタン (右端にアイコンを寄せたければRowを使う)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(
+                  Icons.send,
+                  color: Colors.blueAccent,
+                ),
+                onPressed: () async {
+                  // このボタンで「期日」「週あたり作業時間」「メッセージ」を一括でFirestoreへ保存
+                  final deadlineText = _deadlineController.text.trim();
+                  final weeklyHoursText = _weeklyHoursController.text.trim();
+                  final messageText = _messageController.text.trim();
+
+                  if (deadlineText.isEmpty ||
+                      weeklyHoursText.isEmpty ||
+                      messageText.isEmpty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('すべての項目を入力してください')),
+                    );
+                    return;
+                  }
+
+                  // DateTimeへの変換
+                  try {
+                    final parts = deadlineText.split('/');
+                    final year = int.parse(parts[0]);
+                    final month = int.parse(parts[1]);
+                    final day = int.parse(parts[2]);
+                    final deadlineDate = DateTime(year, month, day);
+
+                    final weeklyHours = double.parse(weeklyHoursText);
+
+                    // Firestore 登録処理（chatViewModel にまとめて実装）
+                    await widget.chatViewModel.addGoalDataAndFirstMessage(
+                      context: context,
+                      userId: widget.userId,
+                      goalId: widget.goalId,
+                      deadline: deadlineDate,
+                      weeklyHours: weeklyHours,
+                      message: messageText,
+                    );
+
+                    // 入力欄をクリア
+                    _deadlineController.clear();
+                    _weeklyHoursController.clear();
+                    _messageController.clear();
+
+                  } catch (e) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('入力値が不正です: $e')),
+                    );
+                  }
+                },
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 概要
- 初回入力フォームを作りました。
  - 目標設定後の初回のみ（Firestoreのsnapshot.data.docsが空のときのみ）期日、週あたり作業時間、目標入力のフォームを表示します。

# 詳細
- 初回入力時はFirstInputWidget, 2回目以降はChatInputWidgetと、部品を別クラスにしました。
- FirstInputWIdget, ChatInputWIdgetそれぞれで、入力時はchatViewModelのaddGoalDataAndFirstMessageメソッド、addMessageメソッドをコールします。メソッドの中身はまだ仮です。