### PR TITLE
タスクを生成した時にタスクをFireStoreに保存するようにした

### DIFF
--- a/backend/src/chatbot/Config/DatabaseConfig.py
+++ b/backend/src/chatbot/Config/DatabaseConfig.py
@@ -2,3 +2,4 @@ class DatabaseConfig:
     USERS_COLLECTION_NAME = "users"
     GOALS_COLLECTION_NAME = "goals"
     CHAT_HISTORY_COLLECTION_NAME = "chat"
+    TASKS_COLLECTION_NAME = "tasks"

--- a/backend/src/chatbot/Dockerfile
+++ b/backend/src/chatbot/Dockerfile
@@ -7,7 +7,7 @@ ENV TZ=Asia/Tokyo
 # PROJECT_IDはご自身のプロジェクトIDに変更してください
 ENV PROJECT_ID=tasktrail-ao
 ENV VERTEX_AI_LOCATION=asia-northeast1
-
+ENV GENERATIVE_MODEL_NAME=gemini-1.5-flash-preview-0514
 WORKDIR /app
 
 COPY requirements.txt .

--- a/backend/src/chatbot/Dockerfile
+++ b/backend/src/chatbot/Dockerfile
@@ -3,6 +3,12 @@ FROM python:3.11-slim
 # タイムゾーンを設定
 ENV TZ=Asia/Tokyo
 
+# ここで、コンパイラや geos ライブラリをインストール
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libgeos-dev \
+ && rm -rf /var/lib/apt/lists/*
+
 # GCPプロジェクトIDとVertex AIのリージョンを設定
 # PROJECT_IDはご自身のプロジェクトIDに変更してください
 ENV PROJECT_ID=tasktrail-ao

--- a/backend/src/chatbot/Http/Api/Schemas.py
+++ b/backend/src/chatbot/Http/Api/Schemas.py
@@ -28,3 +28,17 @@ class GoalGenerateResponse(BaseModel):
     message: str = Field(..., description="LLMからのメッセージ 画面に表示するメッセージ")
     tasks: List[Task] = Field(..., description="生成されたタスクリスト")
     error: Optional[str] = Field(None, description="エラーが発生した場合のメッセージ")
+
+class TaskSaveRequest(BaseModel):
+    """タスク保存リクエストのスキーマ定義"""
+
+    tasks: List[Task] = Field(..., description="タスク一覧")
+    userId: str = Field(..., description="ユーザーID Firebase Auth ID")
+    goalId: str = Field(..., description="目標ID")
+
+class TaskSaveResponse(BaseModel):
+    """タスク保存レスポンスのスキーマ定義"""
+
+    success: bool = Field(..., description="処理の成否")
+    message: str = Field(..., description="メッセージ 成功時は'タスクを保存しました'、失敗時は'タスクの保存に失敗しました")
+    error: Optional[str] = Field(None, description="エラーが発生した場合のメッセージ")

--- a/backend/src/chatbot/Infrastructure/Firebase/FirebaseClient.py
+++ b/backend/src/chatbot/Infrastructure/Firebase/FirebaseClient.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Optional
+
+import firebase_admin
+from firebase_admin import credentials, firestore
+from google.cloud.firestore_v1.client import Client
+
+logger = logging.getLogger(__name__)
+
+class FirebaseClient:
+    """Firebaseクライアントのシングルトンクラス"""
+    
+    _instance: Optional["FirebaseClient"] = None
+    _db: Optional[Client] = None
+    _initialized: bool = False
+
+    def __new__(cls) -> "FirebaseClient":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if not self._initialized:
+            self._initialize_firebase()
+            self._initialized = True
+
+    def _initialize_firebase(self) -> None:
+        """Firebaseの初期化を行う"""
+        try:
+            # デフォルトの認証情報を使用
+            cred = credentials.ApplicationDefault()
+            logger.info(f"cred: {cred}")
+
+            # アプリがまだ初期化されていない場合のみ初期化
+            if not firebase_admin._apps:
+                firebase_admin.initialize_app(cred)
+                logger.info("Firebase app initialized successfully")
+
+            # Firestoreクライアントの初期化
+            self._db = firestore.client()
+            logger.info("Firestore client initialized successfully")
+
+        except Exception as e:
+            logger.error(f"Firestore initialization failed: {e}", exc_info=True)
+            raise
+
+    @property
+    def db(self) -> Client:
+        """Firestoreクライアントを取得する"""
+        if self._db is None:
+            raise RuntimeError("Firestore client is not initialized")
+        return self._db
+
+    @classmethod
+    def get_instance(cls) -> "FirebaseClient":
+        """FirebaseClientのインスタンスを取得する"""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance 

--- a/backend/src/chatbot/Repositories/TaskRepository.py
+++ b/backend/src/chatbot/Repositories/TaskRepository.py
@@ -34,6 +34,13 @@ class TaskRepository:
                 .collection(DatabaseConfig.USERS_COLLECTION_NAME).document(userId) \
                 .collection(DatabaseConfig.GOALS_COLLECTION_NAME).document(goalId) \
                 .collection(DatabaseConfig.TASKS_COLLECTION_NAME)
+
+            # 既存のタスクを削除してから新しいタスクを追加する
+            delete_batch = self._db.batch()
+            for task_doc in tasks_ref.stream():
+                delete_batch.delete(task_doc.reference)
+            delete_batch.commit()
+
             """
              FireStoreのバッチ書き込みを開始
              バッチ書き込みは、複数のFireStore操作をまとめてアトミックに実行するための仕組み

--- a/backend/src/chatbot/Repositories/TaskRepository.py
+++ b/backend/src/chatbot/Repositories/TaskRepository.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import datetime
+
+from Config.DatabaseConfig import DatabaseConfig
+from Domain.Models.TaskCollection import TaskCollection
+from Infrastructure.Firebase.FirebaseClient import FirebaseClient
+
+logger = logging.getLogger(__name__)
+
+
+class TaskRepository:
+    """
+    Firestoreを使用したタスクの永続化を担当するクラス
+    タスクは目標を達成するためのものなので、Goalsの子コレクションとして保存する
+    """
+    def __init__(self):
+        self._firebase = FirebaseClient.get_instance()
+        self._db = self._firebase.db
+        logger.info("TaskRepository initialized with FirebaseClient")
+
+    def add(self, tasks: TaskCollection, userId: str, goalId: str) -> None:
+        """
+        タスクを保存する
+
+        Args:
+            tasks (TaskCollection): タスク一覧
+            userId (str): ユーザーID Firebase Auth ID
+            goalId (str): 目標ID
+        """
+        try:
+            logger.info(f"Saving tasks to goals collection: {tasks.toDict()}")
+            # タスクの一覧をGoalsの子コレクションとして保存する
+            tasks_ref = self._db \
+                .collection(DatabaseConfig.USERS_COLLECTION_NAME).document(userId) \
+                .collection(DatabaseConfig.GOALS_COLLECTION_NAME).document(goalId) \
+                .collection(DatabaseConfig.TASKS_COLLECTION_NAME)
+            """
+             FireStoreのバッチ書き込みを開始
+             バッチ書き込みは、複数のFireStore操作をまとめてアトミックに実行するための仕組み
+             ここでは、複数のタスクを一度にFireStoreに書き込むために使用しています。
+             これにより、個別に書き込むよりも効率的に処理を行うことができ、
+             全てのタスクが保存されるか、全く保存されないかの原子性を保証できます。
+            """
+            batch = self._db.batch()
+            for task_dict in tasks.toDict():
+                task_ref = tasks_ref.document()
+                batch.set(task_ref, {**task_dict, 'created_at': datetime.now()})
+
+            # バッチ書き込みを実行 (バッチ内の全ての操作が成功するか、全てロールバックされます)
+            batch.commit()
+            logger.info("Saved tasks to goals collection")
+        except Exception as e:
+            logger.error(f"Failed to save tasks: {e}", exc_info=True)
+            raise  # 呼び出し元で例外をハンドリングできるように再送出

--- a/backend/src/chatbot/UseCases/GenerateTaskUseCase.py
+++ b/backend/src/chatbot/UseCases/GenerateTaskUseCase.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from Domain.Models.Chat import ChatMessage, ChatRole
 from Repositories.ChatRepository import ChatHistoryRepository
+from Repositories.TaskRepository import TaskRepository
 from Services.ChatService import ChatService
 
 logger = logging.getLogger(__name__)
@@ -14,30 +15,38 @@ class GenerateTaskUseCase:
 
     @dataclass
     class Input:
-
         prompt: str  # ユーザーからの入力テキスト
         userId: str  # ユーザーID Firebase Auth ID
         goalId: Optional[str] = None  # 目標を識別するためのID
-        deadline: Optional[str] = None  # 目標の期日 (YYYY-MM-DD形式) 目標をいつまでに達成したいか
-        weeklyHours: Optional[int] = None  # 週あたりの作業時間 (時間) 目標を達成するために1週間にかける時間
+        deadline: Optional[str] = (
+            None  # 目標の期日 (YYYY-MM-DD形式) 目標をいつまでに達成したいか
+        )
+        weeklyHours: Optional[int] = (
+            None  # 週あたりの作業時間 (時間) 目標を達成するために1週間にかける時間
+        )
 
     @dataclass
     class Output:
-
         status: str  # "success" または "error" または "please_retype_prompt"
         message: str  # ユーザーに表示するメッセージ
         tasks: Optional[List[dict]] = None  # タスクのリスト（成功時のみ存在）
         errorMessage: Optional[str] = None  # エラーメッセージ（エラー時のみ存在）
 
-    def __init__(self, chatService: ChatService, chatHistoryRepository: ChatHistoryRepository):
+    def __init__(
+        self,
+        chatService: ChatService,
+        chatHistoryRepository: ChatHistoryRepository,
+        taskRepository: TaskRepository,
+    ):
         """
-
         Args:
             chatService: チャットサービス
-            chatRepository: チャットリポジトリ
+            chatHistoryRepository: チャットリポジトリ
+            taskRepository: タスクリポジトリ
         """
         self.chatService = chatService
         self.chatHistoryRepository = chatHistoryRepository
+        self.taskRepository = taskRepository
 
     def generate(self, input: Input) -> Output:
         """
@@ -58,12 +67,15 @@ class GenerateTaskUseCase:
         logger.info(f"chatHistory: {chatHistory}")
         try:
             # LLMにプロンプトと過去のやりとりを渡してタスクを生成してもらう
-            chatServiceInput = self.chatService.GenerateResponseInput(prompt=input.prompt, chatHistory=chatHistory)
+            chatServiceInput = self.chatService.GenerateResponseInput(
+                prompt=input.prompt,
+                chatHistory=chatHistory
+            )
             # タスクを生成する
             result = self.chatService.generateResponse(chatServiceInput)
             logger.info(f"Result: {result}")
             if result.status == "error":
-                logger.error(f"Error {result.error_code}: {result.message}")
+                logger.error(f"Error {result.error}: {result.message}")
                 return self.Output(
                     status="error",
                     message=result.message,
@@ -76,7 +88,7 @@ class GenerateTaskUseCase:
                     message=result.message,
                     errorMessage=result.error,
                 )
-            # ユーザーのプロンプトとLLMの回答結果を保存する
+
             chatMessages = []
             chatMessages.append(
                 ChatMessage(
@@ -84,7 +96,6 @@ class GenerateTaskUseCase:
                     content=input.prompt,
                 )
             )
-
             chatMessages.append(
                 ChatMessage(
                     role=ChatRole.ASSISTANT,
@@ -93,16 +104,32 @@ class GenerateTaskUseCase:
                 )
             )
             self.chatHistoryRepository.add(chatMessages, input.userId, input.goalId)
-            logger.info("Saved response to repository")
+            logger.info("Saved chat history to repository")
 
+            # タスクの保存
+            if result.tasks:
+                try:
+                    self.taskRepository.add(
+                        tasks=result.tasks, userId=input.userId, goalId=input.goalId
+                    )
+                    logger.info("Saved tasks to repository")
+                except Exception as e:
+                    logger.error(f"Failed to save tasks: {e}", exc_info=True)
+                    return self.Output(
+                        status="error",
+                        message="タスクの保存に失敗しました。再度お試しください。",
+                        errorMessage="task_save_failed",  # エラーコードを追加
+                    )
 
             # 成功の場合
             return self.Output(
                 status="success",
                 message=result.message,
-                tasks=result.tasks.toDict() if result.tasks else None
+                tasks=result.tasks.toDict() if result.tasks else None,
             )
 
         except Exception as e:
             logger.error(f"Error in generate: {e}", exc_info=True)
-            return self.Output(status="error", errorMessage=str(e),message="エラーが発生しました。")
+            return self.Output(
+                status="error", errorMessage=str(e), message="エラーが発生しました。"
+            )

--- a/backend/src/chatbot/UseCases/SaveTaskUseCase.py
+++ b/backend/src/chatbot/UseCases/SaveTaskUseCase.py
@@ -1,0 +1,61 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+from Domain.Models.Task import Task
+from Domain.Models.TaskCollection import TaskCollection
+from Repositories.TaskRepository import TaskRepository
+
+logger = logging.getLogger(__name__)
+
+class SaveTaskUseCase:
+    """タスク保存に関するユースケースを担当するクラス"""
+
+    @dataclass
+    class Input:
+
+        tasks: List[dict]  # タスク一覧
+        userId: str  # ユーザーID Firebase Auth ID
+        goalId: str  # 目標ID
+
+    @dataclass
+    class Output:
+
+        success: bool  # 処理の成否
+        message: str  # ユーザーに表示するメッセージ
+        errorMessage: Optional[str] = None  # エラーメッセージ（エラー時のみ存在）
+
+    def __init__(self,taskRepository: TaskRepository):
+        self.taskRepository = taskRepository
+
+    def save(self, input: Input) -> Output:
+        """
+        LLMが生成したタスクに対してユーザが納得した場合は、そのタスクを保存する
+
+        Args:
+            input (Input): タスク保存リクエスト
+        """
+        # # タスクを保存する
+        # taskCollection = TaskCollection()
+        # logger.info(f"input.tasks: {input.tasks}")
+        # # dict型のタスクをTaskCollectionに変換する
+        # taskCollection = self._convertDictToTaskCollection(input.tasks)
+        # self.taskRepository.add(tasks=taskCollection, userId=input.userId, goalId=input.goalId)
+        
+        # TODO GoogleCalenderのTODOにタスクを追加する
+
+        return self.Output(success=True, message="タスクを保存しました")
+
+    def _convertDictToTaskCollection(self, tasksJson: List[dict]) -> TaskCollection:
+        taskCollection = TaskCollection()
+        for task_dict in tasksJson:
+            task = Task(
+                title=task_dict["title"],
+                description=task_dict["description"],
+                deadline=task_dict["deadline"],
+                requiredTime=int(task_dict["requiredTime"]),
+                priority=int(task_dict["priority"]),
+            )
+            taskCollection.add(task)
+        return taskCollection

--- a/backend/src/chatbot/UseCases/SaveTaskUseCase.py
+++ b/backend/src/chatbot/UseCases/SaveTaskUseCase.py
@@ -1,6 +1,5 @@
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from typing import List, Optional
 
 from Domain.Models.Task import Task


### PR DESCRIPTION
以下のPRのユースケースにタスクを保存する処理を追加しました。
https://github.com/kassy-vvt/TaskTrail/pull/35

## このPRで出来るようになったこと

`/api/goal/generate` にリクエストが送信された時に、タスクを保存するようにしました。

現行ではタスクを生成してレスポンスに返却するだけです。

## 処理実行後の状態

fire-storeに保存されることを確認しました
https://console.firebase.google.com/project/ai-hackathon-test1/firestore/databases/-default-/data/~2Fusers~2F123~2Fgoals~2Ftoeic~2Ftasks~2FUlZ2lwCK5IrACKtqSEwW