### PR TITLE
[WIP]目標作成後、AI から応答が来るまで loading 表示する機能の追加

### DIFF
--- a/frontend/flutter_app/lib/view/chat_page.dart
+++ b/frontend/flutter_app/lib/view/chat_page.dart
@@ -95,6 +95,16 @@ class ChatPage extends ConsumerWidget {
                           onTap: () {
                             // 目標を選択
                             chatViewModel.setSelectedGoalId(goalId, goal);
+
+                            // FIXME ここで Loading を false にするのは適切ではない。
+                            // 本当は[chatStream]を読み込んだ後にfalseにするべき
+                            // 現在、isLoading を viewmodel で管理している && chat_tab_widget.dart への遷移が
+                            // Stream 契機で、そこで viewmodel の メンバ変数の変更が出来ない。
+                            // そのためここで Loading の初期化を行っている
+                            // 本来は chat_tab_widget.dart を表示するタイミングで Loading を false にするべき
+
+                            // Loading の状態を初期化
+                            chatViewModel.setLoading(false);
                             Navigator.pop(context); // Drawer を閉じる
                           },
                         );

--- a/frontend/flutter_app/lib/view/first_input_widget.dart
+++ b/frontend/flutter_app/lib/view/first_input_widget.dart
@@ -1,11 +1,6 @@
 // lib/view/chat_page.dart
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hackathon_test1/view/common/add_goal_button.dart';
 import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
-import 'package:hackathon_test1/viewmodel/goal_viewmodel.dart';
 
 class FirstInputWidget extends StatefulWidget {
   final ChatViewModel chatViewModel;
@@ -13,11 +8,11 @@ class FirstInputWidget extends StatefulWidget {
   final String goalId;
 
   const FirstInputWidget({
-    Key? key,
+    super.key,
     required this.chatViewModel,
     required this.userId,
     required this.goalId,
-  }) : super(key: key);
+  });
 
   @override
   State<FirstInputWidget> createState() => _FirstInputWidgetState();
@@ -30,131 +25,133 @@ class _FirstInputWidgetState extends State<FirstInputWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding:
-      const EdgeInsets.only(right: 16.0, left: 16.0, bottom: 32.0, top: 8.0),
-      // 下に寄せるために、上に大きな余白をとらないようにしています
-      child: Column(
-        mainAxisSize: MainAxisSize.min, // 必要最小限の高さに
-        children: [
-          // 期日 (カレンダーPicker)
-          TextField(
-            controller: _deadlineController,
-            decoration: const InputDecoration(
-              labelText: '期日を選択',
-              border: OutlineInputBorder(),
-              suffixIcon: Icon(Icons.calendar_today),
-            ),
-            readOnly: true,
-            onTap: () async {
-              final pickedDate = await showDatePicker(
-                context: context,
-                initialDate: DateTime.now(),
-                firstDate: DateTime(2020),
-                lastDate: DateTime(2100),
-              );
-              if (pickedDate != null) {
-                setState(() {
-                  _deadlineController.text =
-                  "${pickedDate.year}/${pickedDate.month}/${pickedDate.day}";
-                });
-              }
-            },
-          ),
-          const SizedBox(height: 8),
-
-          // 週あたり作業時間
-          TextField(
-            controller: _weeklyHoursController,
-            keyboardType: TextInputType.number,
-            decoration: const InputDecoration(
-              labelText: '週あたり作業時間(時間)',
-              border: OutlineInputBorder(),
-            ),
-          ),
-          const SizedBox(height: 8),
-
-          // メッセージ入力
-          Container(
-            height: 60,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: Colors.grey),
-            ),
-            child: TextField(
-              controller: _messageController,
-              decoration: const InputDecoration(
-                hintText: '目標を入力してください',
-                border: InputBorder.none,
-                contentPadding: EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 16,
-                ),
-              ),
-            ),
-          ),
-
-          // 送信ボタン (右端にアイコンを寄せたければRowを使う)
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              IconButton(
-                icon: const Icon(
-                  Icons.add,
-                  color: Colors.blueAccent,
-                ),
-                onPressed: () async {
-                  // このボタンで「期日」「週あたり作業時間」「メッセージ」を一括でFirestoreへ保存
-                  final deadlineText = _deadlineController.text.trim();
-                  final weeklyHoursText = _weeklyHoursController.text.trim();
-                  final messageText = _messageController.text.trim();
-
-                  if (deadlineText.isEmpty ||
-                      weeklyHoursText.isEmpty ||
-                      messageText.isEmpty) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('すべての項目を入力してください')),
-                    );
-                    return;
-                  }
-
-                  // DateTimeへの変換
-                  try {
-                    final parts = deadlineText.split('/');
-                    final year = int.parse(parts[0]);
-                    final month = int.parse(parts[1]);
-                    final day = int.parse(parts[2]);
-                    final deadlineDate = DateTime(year, month, day);
-
-                    final weeklyHours = double.parse(weeklyHoursText);
-
-                    // Firestore 登録処理（chatViewModel にまとめて実装）
-                    await widget.chatViewModel.addGoalDataAndFirstMessage(
+    return widget.chatViewModel.isLoading
+        ? const Center(child: CircularProgressIndicator())
+        : Padding(
+            padding: const EdgeInsets.only(
+                right: 16.0, left: 16.0, bottom: 32.0, top: 8.0),
+            // 下に寄せるために、上に大きな余白をとらないようにしています
+            child: Column(
+              mainAxisSize: MainAxisSize.min, // 必要最小限の高さに
+              children: [
+                // 期日 (カレンダーPicker)
+                TextField(
+                  controller: _deadlineController,
+                  decoration: const InputDecoration(
+                    labelText: '期日を選択',
+                    border: OutlineInputBorder(),
+                    suffixIcon: Icon(Icons.calendar_today),
+                  ),
+                  readOnly: true,
+                  onTap: () async {
+                    final pickedDate = await showDatePicker(
                       context: context,
-                      userId: widget.userId,
-                      goalId: widget.goalId,
-                      deadline: deadlineDate,
-                      weeklyHours: weeklyHours,
-                      message: messageText,
+                      initialDate: DateTime.now(),
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime(2100),
                     );
+                    if (pickedDate != null) {
+                      setState(() {
+                        _deadlineController.text =
+                            "${pickedDate.year}/${pickedDate.month}/${pickedDate.day}";
+                      });
+                    }
+                  },
+                ),
+                const SizedBox(height: 8),
 
-                    // 入力欄をクリア
-                    _deadlineController.clear();
-                    _weeklyHoursController.clear();
-                    _messageController.clear();
+                // 週あたり作業時間
+                TextField(
+                  controller: _weeklyHoursController,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '週あたり作業時間(時間)',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                const SizedBox(height: 8),
 
-                  } catch (e) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('入力値が不正です: $e')),
-                    );
-                  }
-                },
-              ),
-            ],
-          )
-        ],
-      ),
-    );
+                // メッセージ入力
+                Container(
+                  height: 60,
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: Colors.grey),
+                  ),
+                  child: TextField(
+                    controller: _messageController,
+                    decoration: const InputDecoration(
+                      hintText: '目標を入力してください',
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 16,
+                      ),
+                    ),
+                  ),
+                ),
+
+                // 送信ボタン (右端にアイコンを寄せたければRowを使う)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    IconButton(
+                      icon: const Icon(
+                        Icons.add,
+                        color: Colors.blueAccent,
+                      ),
+                      onPressed: () async {
+                        // このボタンで「期日」「週あたり作業時間」「メッセージ」を一括でFirestoreへ保存
+                        final deadlineText = _deadlineController.text.trim();
+                        final weeklyHoursText =
+                            _weeklyHoursController.text.trim();
+                        final messageText = _messageController.text.trim();
+
+                        if (deadlineText.isEmpty ||
+                            weeklyHoursText.isEmpty ||
+                            messageText.isEmpty) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('すべての項目を入力してください')),
+                          );
+                          return;
+                        }
+
+                        // DateTimeへの変換
+                        try {
+                          final parts = deadlineText.split('/');
+                          final year = int.parse(parts[0]);
+                          final month = int.parse(parts[1]);
+                          final day = int.parse(parts[2]);
+                          final deadlineDate = DateTime(year, month, day);
+
+                          final weeklyHours = double.parse(weeklyHoursText);
+
+                          // Firestore 登録処理（chatViewModel にまとめて実装）
+                          await widget.chatViewModel.addGoalDataAndFirstMessage(
+                            context: context,
+                            userId: widget.userId,
+                            goalId: widget.goalId,
+                            deadline: deadlineDate,
+                            weeklyHours: weeklyHours,
+                            message: messageText,
+                          );
+
+                          // 入力欄をクリア
+                          _deadlineController.clear();
+                          _weeklyHoursController.clear();
+                          _messageController.clear();
+                        } catch (e) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('入力値が不正です: $e')),
+                          );
+                        }
+                      },
+                    ),
+                  ],
+                )
+              ],
+            ),
+          );
   }
 }

--- a/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
@@ -11,8 +11,16 @@ final chatViewModelProvider = ChangeNotifierProvider((ref) => ChatViewModel());
 class ChatViewModel extends ChangeNotifier {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final TextEditingController textController = TextEditingController();
+  bool _isLoading = false;
   String? selectedGoalId;
   String? selectedGoalText; // 追加: 選択した目標の文言
+
+  bool get isLoading => _isLoading;
+
+  void setLoading(bool isLoading) {
+    _isLoading = isLoading;
+    notifyListeners();
+  }
 
   // メッセージを Firestore に追加
   Future<void> addMessage(String notebookId, BuildContext context) async {
@@ -79,8 +87,8 @@ class ChatViewModel extends ChangeNotifier {
         .collection('goals')
         .doc(goalId)
         .collection('tasks')
-    // 並び順を指定したい場合（例：priority 昇順）
-    // .orderBy('priority', descending: false)
+        // 並び順を指定したい場合（例：priority 昇順）
+        // .orderBy('priority', descending: false)
         .snapshots();
   }
 
@@ -132,6 +140,7 @@ class ChatViewModel extends ChangeNotifier {
           ).toJson());
 
       SnackbarHelper.show(context, '期日・作業時間・メッセージを保存しました');
+      setLoading(true); // Loading 開始
     } catch (e) {
       SnackbarHelper.show(context, 'Firestore 書き込みエラー: $e');
     }


### PR DESCRIPTION
## 概要

新規目標作成後、AI からの応答を待つ間のローディング表示と操作に関する問題を修正しました。

## 変更内容

- 新規目標作成後、AI から返答が来るまでの間、ローディング画面を表示するように変更しました。
  - これにより、ユーザーは AI の処理中であることを認識でき、操作不能になることを防ぎます。

## 課題と暫定対応

- **⚠️課題:** 本来、AI から応答を受け取ったタイミングでローディング画面を非表示にすることが理想ですが、現在の実装上の制約により実現できませんでした。
- **影響:** この制約により、新規目標作成後に他の目標を作成しようとすると、ローディング画面が表示されたままになります。
- **暫定対応:** この問題を回避するため、**ドロワーメニューから目標を選択した際にローディング画面を非表示にする** 暫定対応を行いました。
  - 現状、他の目標への遷移方法がドロワーメニューからの選択しかないため、この方法で影響を最小限に抑えています。

## 今後の対応

AI からの応答を受信したタイミングでローディング画面を非表示にする処理は、今後の課題として FIXME コメントを付与しています。

## その他

- 暫定対応により、他の目標作成時にローディング画面が表示される問題は回避されます。

## 動画
https://github.com/user-attachments/assets/418a3f56-3122-4d97-a315-668be83c85e9