### PR TITLE
created_atとcreatedAtの混在をcreatedAtに統一

### DIFF
--- a/backend/src/chatbot/Repositories/ChatRepository.py
+++ b/backend/src/chatbot/Repositories/ChatRepository.py
@@ -27,7 +27,7 @@ class ChatHistoryRepository:
                 chatMessageData = {
                     "role": chatMessage.role,
                     "content": chatMessage.content,
-                    "created_at": chatMessage.createdAt.isoformat(),
+                    "createdAt": chatMessage.createdAt.isoformat(),
                     "status": chatMessage.status,
                 }
                 # タスクがある場合はタスクを追加
@@ -71,7 +71,7 @@ class ChatHistoryRepository:
                     message_data = {
                         "role": ChatRole(data.get("role")),
                         "content": data.get("content"),
-                        "createdAt": datetime.fromisoformat(data.get("created_at")),
+                        "createdAt": datetime.fromisoformat(data.get("createdAt")),
                         "status": ChatStatus(data.get("status")),
                     }
                     # タスクがある場合はタスクを追加

--- a/backend/src/chatbot/Repositories/TaskRepository.py
+++ b/backend/src/chatbot/Repositories/TaskRepository.py
@@ -51,7 +51,7 @@ class TaskRepository:
             batch = self._db.batch()
             for task_dict in tasks.toDict():
                 task_ref = tasks_ref.document()
-                batch.set(task_ref, {**task_dict, 'created_at': datetime.now()})
+                batch.set(task_ref, {**task_dict, 'createdAt': datetime.now()})
 
             # バッチ書き込みを実行 (バッチ内の全ての操作が成功するか、全てロールバックされます)
             batch.commit()

--- a/frontend/flutter_app/lib/view/chat_tab_widget.dart
+++ b/frontend/flutter_app/lib/view/chat_tab_widget.dart
@@ -58,7 +58,7 @@ class ChatTabWidget extends ConsumerWidget {
                   final content = data['content'] as String? ?? '';
                   final role = data['role'] as String? ?? 'user';
                   // Timestamp → DateTime への変換
-                  final createdAt = data['created_at'];
+                  final createdAt = data['createdAt'];
                   DateTime? createdTime;
                   if (createdAt is Timestamp) {
                     createdTime = createdAt.toDate();

--- a/frontend/flutter_app/lib/view/tasks_tab_widget.dart
+++ b/frontend/flutter_app/lib/view/tasks_tab_widget.dart
@@ -54,7 +54,7 @@ class TaskTabWidget extends ConsumerWidget {
             final description = data['description'] as String? ?? '';
             final priority = data['priority'] as int? ?? 0;
             final deadline = data['deadline']; // Timestamp 形式の場合あり
-            final createdAt = data['created_at']; // Timestamp 形式の場合あり
+            final createdAt = data['createdAt']; // Timestamp 形式の場合あり
             final requiredTime = data['requiredTime'] as int? ?? 0;
 
             // Timestamp から DateTime への変換例（Firestore の Timestamp の場合）

--- a/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
@@ -53,7 +53,7 @@ class ChatViewModel extends ChangeNotifier {
         .collection('goals')
         .doc(goalId)
         .collection('chat')
-        .orderBy('created_at', descending: false)
+        .orderBy('createdAt', descending: false)
         .snapshots();
   }
 
@@ -79,8 +79,8 @@ class ChatViewModel extends ChangeNotifier {
         .collection('goals')
         .doc(goalId)
         .collection('tasks')
-    // 並び順を指定したい場合（例：priority 昇順）
-    // .orderBy('priority', descending: false)
+        // 並び順を指定したい場合（例：priority 昇順）
+        // .orderBy('priority', descending: false)
         .snapshots();
   }
 


### PR DESCRIPTION
- Firestoreのパラメータがcreated_atとcreatedAtで混在している。
- このせいでいくつか不具合が起きるため、createdAtに統一します。