### PR TITLE
生成したタスクをベースに、詳細TODOをGoogleカレンダーに設定できるようになった

### DIFF
--- a/backend/src/chatbot/Http/Api/Routes.py
+++ b/backend/src/chatbot/Http/Api/Routes.py
@@ -227,9 +227,15 @@ async def save_task(request: TaskSaveRequest) -> TaskSaveResponse:
         error=saveTaskUseCaseOutput.errorMessage,
     )
 
+@router.post("/api/chat/eventarc")
+async def handle_eventarc(request: Request):
+    data = await request.json()
+    print("Received Eventarc data:", data)
+    return {"status": "ok"}
 
 @router.get("/api/health")
 async def health_check() -> dict:
     """ヘルスチェックエンドポイント"""
     logger.debug("Health check requested")
     return {"status": "healthy"}
+

--- a/backend/src/chatbot/Http/Api/Routes.py
+++ b/backend/src/chatbot/Http/Api/Routes.py
@@ -196,22 +196,12 @@ def sync_tasks_endpoint(tasks: List[dict],
 
     access_token = authorization.replace("Bearer ", "")
 
-    # ※ 実際には必要に応じて client_id, client_secret を取得
-    client_id = "tekito"
-    client_secret = "tekito"
-
-    # 今回は refresh_token なし（None のまま）
-    refresh_token = None
-
     service = TaskSyncService(
-        access_token=access_token,
-        refresh_token=refresh_token,
-        client_id=client_id,
-        client_secret=client_secret
+        access_token=access_token
     )
     # Pydanticモデルをdictに変換し、リスト化してsync_tasksに渡す
     # tasks_dict_list = [task.dict() for task in tasks]
-    result = service.sync_tasks(tasks, access_token, refresh_token, client_id, client_secret)
+    result = service.sync_tasks(tasks, access_token)
     return result
 
 @router.post("/api/task/save", response_model=TaskSaveResponse)

--- a/backend/src/chatbot/Services/TaskSyncService/daily_allocation.py
+++ b/backend/src/chatbot/Services/TaskSyncService/daily_allocation.py
@@ -1,9 +1,9 @@
 from datetime import date, datetime, timedelta, time
 import math
 
-import day_slot_calculator
-import urgency_calculator
-import tasks_api_client
+from . import day_slot_calculator
+from . import urgency_calculator
+from . import tasks_api_client
 
 TASK_TITLE = "AI hackathon Tasks"
 
@@ -158,11 +158,11 @@ def allocate_tasks_day_by_day(
     return tasks, allocated_slots
 
 
-def main():
+def main(access_token, refresh_token, client_id, client_secret):
     # スロット計算プログラムから「日毎の稼働可能なスロット数」を取得
     start_dt = datetime(2025, 1, 26)
     end_dt = datetime(2025, 1, 28)
-    day_slots_map = day_slot_calculator.get_day_slot_map(start_dt, end_dt)
+    day_slots_map = day_slot_calculator.get_day_slot_map(start_dt, end_dt, access_token, refresh_token, client_id, client_secret)
     
     # タスク一覧(JSON)をロード & 緊急度を最初に計算
     tasks = urgency_calculator.load_tasks_from_json("tests/input_tasks.json")

--- a/backend/src/chatbot/Services/TaskSyncService/day_slot_calculator.py
+++ b/backend/src/chatbot/Services/TaskSyncService/day_slot_calculator.py
@@ -1,9 +1,6 @@
-import os
-import math
 from datetime import datetime, timedelta, time
 import dateutil.parser  # pip install python-dateutil
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
 # カレンダーAPIのスコープ: 読み取り専用にする場合

--- a/backend/src/chatbot/Services/TaskSyncService/day_slot_calculator.py
+++ b/backend/src/chatbot/Services/TaskSyncService/day_slot_calculator.py
@@ -9,7 +9,7 @@ from googleapiclient.discovery import build
 # カレンダーAPIのスコープ: 読み取り専用にする場合
 CALENDAR_SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 
-def get_calendar_service(access_token, refresh_token, client_id, client_secret):
+def get_calendar_service(access_token):
     """
     GoogleカレンダーAPIのServiceインスタンスを返す。
     ローカルPCなどで実行し、ブラウザ認証することを想定。
@@ -111,8 +111,8 @@ def decide_num_tasks(booked_hours):
     else:
         return 2
     
-def get_day_slot_map(start_date, end_date, access_token, refresh_token, client_id, client_secret):
-    cal_service = get_calendar_service(access_token, refresh_token, client_id, client_secret)
+def get_day_slot_map(start_date, end_date, access_token):
+    cal_service = get_calendar_service(access_token)
     calendar_id = "primary"
     day_booked_map = get_daily_booked_hours(cal_service, calendar_id, start_date, end_date)
 
@@ -123,9 +123,9 @@ def get_day_slot_map(start_date, end_date, access_token, refresh_token, client_i
 
     return allocation_result
 
-def main(access_token, refresh_token, client_id, client_secret):
+def main(access_token):
     # 1) カレンダーAPIサービスの初期化
-    cal_service = get_calendar_service(access_token, refresh_token, client_id, client_secret)
+    cal_service = get_calendar_service(access_token)
 
     # 2) 取得したい期間を設定
     today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
+++ b/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
@@ -7,27 +7,32 @@ from .tasks_api_client import get_tasks_service, create_task_list, create_todo_i
 
 class TaskSyncService:
 
-    def __init__(self):
+    def __init__(self, access_token: str, refresh_token: str, client_id: str, client_secret: str):
         # 必要に応じて初期化
-        self.tasks_service = get_tasks_service()
+        self.tasks_service = get_tasks_service(
+                    access_token=access_token,
+                    refresh_token=refresh_token,
+                    client_id=client_id,
+                    client_secret=client_secret
+                )
         self.task_title = "AI hackathon Tasks"
         self.start_dt = date.today()
-        self.end_dt = self.start_date + timedelta(days=7)
+        self.end_dt = self.start_dt + timedelta(days=7)
 
-    def sync_tasks(self, tasks: list[dict]):
+    def sync_tasks(self, tasks: list[dict], access_token, refresh_token, client_id, client_secret):
         """
         受け取ったタスクを、Googleカレンダーの空き状況などを考慮して
         Google Tasks(API)に同期する一連の処理をまとめる。
         """
         # 1. カレンダーから日毎スロット取得
-        day_slots_map = get_day_slot_map(self.start_dt, self.end_dt)
+        day_slots_map = get_day_slot_map(self.start_dt, self.end_dt,access_token, refresh_token, client_id, client_secret)
 
         # 2. 割り当て計算
         updated_tasks, allocated_slots = allocate_tasks_day_by_day(
             tasks=tasks,
             day_slots_map=day_slots_map,
-            start_date=self.start_dt.date(),
-            end_date=self.end_dt.date()
+            start_date=self.start_dt,
+            end_date=self.end_dt
         )
 
         # 3. Google Tasks APIでタスクリスト作成

--- a/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
+++ b/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
@@ -1,7 +1,6 @@
 # task_sync_service.py （例）
 from datetime import datetime, date, timedelta, time
 from .day_slot_calculator import get_day_slot_map
-from .urgency_calculator import calculate_urgencies
 from .daily_allocation import allocate_tasks_day_by_day
 from .tasks_api_client import get_tasks_service, create_task_list, create_todo_in_google_tasks
 

--- a/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
+++ b/backend/src/chatbot/Services/TaskSyncService/task_sync_service.py
@@ -7,25 +7,22 @@ from .tasks_api_client import get_tasks_service, create_task_list, create_todo_i
 
 class TaskSyncService:
 
-    def __init__(self, access_token: str, refresh_token: str, client_id: str, client_secret: str):
+    def __init__(self, access_token: str):
         # 必要に応じて初期化
         self.tasks_service = get_tasks_service(
                     access_token=access_token,
-                    refresh_token=refresh_token,
-                    client_id=client_id,
-                    client_secret=client_secret
                 )
         self.task_title = "AI hackathon Tasks"
         self.start_dt = date.today()
         self.end_dt = self.start_dt + timedelta(days=7)
 
-    def sync_tasks(self, tasks: list[dict], access_token, refresh_token, client_id, client_secret):
+    def sync_tasks(self, tasks: list[dict], access_token):
         """
         受け取ったタスクを、Googleカレンダーの空き状況などを考慮して
         Google Tasks(API)に同期する一連の処理をまとめる。
         """
         # 1. カレンダーから日毎スロット取得
-        day_slots_map = get_day_slot_map(self.start_dt, self.end_dt,access_token, refresh_token, client_id, client_secret)
+        day_slots_map = get_day_slot_map(self.start_dt, self.end_dt,access_token)
 
         # 2. 割り当て計算
         updated_tasks, allocated_slots = allocate_tasks_day_by_day(

--- a/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
+++ b/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
@@ -21,7 +21,7 @@ def list_task_lists(service):
     tasklists = results.get('items', [])
     return tasklists
 
-def get_tasks_service(access_token, refresh_token, client_id, client_secret):
+def get_tasks_service(access_token):
     """
     Google Tasks APIのServiceインスタンスを返す。
     認証情報が保存されていれば再利用し、なければ新たに認証フローを実行する。

--- a/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
+++ b/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
@@ -1,11 +1,6 @@
 # chatbot/services/tasks_api_client.py
-
-import os
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 from googleapiclient.discovery import build
-from datetime import datetime
 
 TASKS_SCOPES = ["https://www.googleapis.com/auth/tasks"]
 

--- a/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
+++ b/backend/src/chatbot/Services/TaskSyncService/tasks_api_client.py
@@ -21,30 +21,19 @@ def list_task_lists(service):
     tasklists = results.get('items', [])
     return tasklists
 
-def get_tasks_service():
+def get_tasks_service(access_token, refresh_token, client_id, client_secret):
     """
     Google Tasks APIのServiceインスタンスを返す。
     認証情報が保存されていれば再利用し、なければ新たに認証フローを実行する。
     """
-    creds = None
-    token_path = "credentials/token_tasks.json"  # 認証結果(トークン)を保存するファイル
-
-    if os.path.exists(token_path):
-        creds = Credentials.from_authorized_user_file(token_path, TASKS_SCOPES)
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-        else:
-            flow = InstalledAppFlow.from_client_secrets_file(
-                "credentials/credentials_desktop.json",  # ダウンロードしたOAuthクレデンシャルファイル
-                TASKS_SCOPES
-            )
-            creds = flow.run_local_server(port=0)  # GUI環境がある場合
-            # ヘッドレス環境の場合は flow.run_console() に変更
-        # 認証した資格情報をファイルに保存 → 次回から再利用
-        with open(token_path, "w") as token:
-            token.write(creds.to_json())
-
+    creds = Credentials(
+        token=access_token,
+        # refresh_token=refresh_token,
+        # token_uri="https://oauth2.googleapis.com/token",  # Google OAuthのトークンエンドポイント
+        # client_id=client_id,
+        # client_secret=client_secret,
+        scopes=TASKS_SCOPES
+    )
     service = build("tasks", "v1", credentials=creds)
     return service
 

--- a/frontend/flutter_app/lib/repository/task_repository.dart
+++ b/frontend/flutter_app/lib/repository/task_repository.dart
@@ -1,0 +1,92 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:convert';           // jsonEncode用
+import 'package:http/http.dart' as http;
+import 'package:flutter/material.dart';
+
+class TaskRepository {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  /// userId と goalId を指定して、tasks コレクションのドキュメントを取得し、
+  /// [
+  ///   {
+  ///     "title": "xxx",
+  ///     "description": "yyy",
+  ///     "deadline": "2025-03-01",
+  ///     "requiredTime": 120
+  ///   },
+  ///   ...
+  /// ]
+  /// のような List<Map<String, dynamic>> を返す
+  Future<List<Map<String, dynamic>>> getTasksAsJson({
+    required String userId,
+    required String goalId,
+  }) async {
+    // Firestore から tasks 一覧を取得
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('goals')
+        .doc(goalId)
+        .collection('tasks')
+        .get();
+
+    // 取得したドキュメントを List<Map<String, dynamic>> に変換
+    final List<Map<String, dynamic>> result = [];
+
+    for (var doc in snapshot.docs) {
+      final data = doc.data();
+
+      // Firestoreに保存されているdeadlineがTimestampの場合はDateTimeに変換
+      final deadlineStr = data['deadline'];
+
+      // JSONとして必要なフィールドをまとめる
+      result.add({
+        "title": data["title"] ?? "",
+        "description": data["description"] ?? "",
+        "deadline": deadlineStr ?? "",       // なければ空文字に
+        "requiredTime": data["requiredTime"] ?? 0,
+      });
+    }
+
+    return result;
+  }
+
+  /// Firestoreからtasksを取得し、JSON化したデータをHTTP POSTする
+  static Future<void> fetchTasksAndPost({
+    required String authToken,
+    required String userId,
+    required String goalId,
+  }) async {
+    final repo = TaskRepository();
+
+    // 1) Firestoreからtasksを取得 → JSONのリストに変換
+    final tasksJsonList = await repo.getTasksAsJson(userId: userId, goalId: goalId);
+
+    // 2) JSON文字列に変換
+    final jsonString = jsonEncode(tasksJsonList);
+
+    // 3) HTTP POSTする
+    const url = 'https://chatbot-api-514173068988.asia-northeast1.run.app/sync-tasks';
+    // ローカル練習用
+    // const url = 'http://192.168.1.49:8080/sync-tasks';
+    try {
+      final response = await http.post(
+        Uri.parse(url),
+        headers: {
+          'Authorization': 'Bearer $authToken',  // Google Auth Token
+          'Content-Type': 'application/json',
+        },
+        body: jsonString,
+      );
+
+      if (response.statusCode == 200) {
+        debugPrint('POST 成功: ${response.body}');
+      } else {
+        debugPrint('POST 失敗: ${response.statusCode} ${response.reasonPhrase}');
+        debugPrint('レスポンス: ${response.body}');
+      }
+    } catch (e) {
+      debugPrint('POST エラー: $e');
+    }
+  }
+}

--- a/frontend/flutter_app/lib/view/tasks_tab_widget.dart
+++ b/frontend/flutter_app/lib/view/tasks_tab_widget.dart
@@ -4,15 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
 
-/// 2つ目のタブ用のレイアウトサンプル
+/// 2つ目のタブ用のサンプルウィジェット
 class TaskTabWidget extends ConsumerWidget {
-  const TaskTabWidget({
-    super.key,
-  });
+  const TaskTabWidget({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // 現在ログイン中のユーザー
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
       // ログインしていない場合
@@ -23,64 +20,115 @@ class TaskTabWidget extends ConsumerWidget {
     final userId = user.uid;
     final selectedGoalId = chatViewModel.selectedGoalId;
 
-    // タスク一覧を取得する Stream
-    final tasksStream = chatViewModel.getTasksStream(userId, selectedGoalId);
+    // goalId が選択されていない場合
+    if (selectedGoalId == null) {
+      return const Center(child: Text('目標が選択されていません'));
+    }
 
-    // タスク一覧を表示
-    return StreamBuilder<QuerySnapshot>(
-      stream: tasksStream,
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          // データ待ちのローディング中
+    // 1) ゴール1件のドキュメントをストリームで監視 (taskFixed の変化を追う)
+    return StreamBuilder<DocumentSnapshot>(
+      stream: chatViewModel.getGoalDocStream(userId, selectedGoalId),
+      builder: (context, goalSnapshot) {
+        if (goalSnapshot.connectionState == ConnectionState.waiting) {
           return const Center(child: CircularProgressIndicator());
         }
-        if (!snapshot.hasData) {
-          return const Center(child: Text('タスクがありません'));
+        if (!goalSnapshot.hasData || !goalSnapshot.data!.exists) {
+          return const Center(child: Text('目標が存在しません'));
         }
 
-        final docs = snapshot.data!.docs;
-        if (docs.isEmpty) {
-          return const Center(child: Text('タスクがありません'));
-        }
+        final goalDoc = goalSnapshot.data!;
+        final data = goalDoc.data() as Map<String, dynamic>?;
 
-        // タスクのリストを表示
-        return ListView.builder(
-          itemCount: docs.length,
-          itemBuilder: (context, index) {
-            final data = docs[index].data() as Map<String, dynamic>;
+        // taskFixed の値を取得 (なければ false 扱い)
+        final bool isTaskFixed = data?['taskFixed'] as bool? ?? false;
 
-            // Firestore の項目
-            final title = data['title'] as String? ?? 'No Title';
-            final description = data['description'] as String? ?? '';
-            final priority = data['priority'] as int? ?? 0;
-            final deadline = data['deadline']; // Timestamp 形式の場合あり
-            final createdAt = data['createdAt']; // Timestamp 形式の場合あり
-            final requiredTime = data['requiredTime'] as int? ?? 0;
-
-            // Timestamp から DateTime への変換例（Firestore の Timestamp の場合）
-            DateTime? deadlineDate;
-            if (deadline != null && deadline is Timestamp) {
-              deadlineDate = deadline.toDate();
+        // 2) タスク一覧をストリームで取得
+        final tasksStream = chatViewModel.getTasksStream(userId, selectedGoalId);
+        return StreamBuilder<QuerySnapshot>(
+          stream: tasksStream,
+          builder: (context, tasksSnapshot) {
+            if (tasksSnapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (!tasksSnapshot.hasData) {
+              return const Center(child: Text('タスクがありません'));
             }
 
-            DateTime? createdDate;
-            if (createdAt != null && createdAt is Timestamp) {
-              createdDate = createdAt.toDate();
+            final docs = tasksSnapshot.data!.docs;
+            if (docs.isEmpty) {
+              // タスクコレクションが空の場合
+              return const Center(child: Text('タスクがありません'));
             }
 
-            return ListTile(
-              title: Text(title),
-              subtitle: Text(
-                '優先度: $priority\n'
-                '必要な時間: $requiredTime 時間\n'
-                '締め切り: ${deadlineDate?.toLocal() ?? '-'}\n'
-                '作成日: ${createdDate?.toLocal() ?? '-'}\n'
-                '$description',
-              ),
-              // それぞれのタスクをタップしたときの処理など
-              onTap: () {
-                // 例: 詳細画面へ遷移するなど
-              },
+            // タスク一覧を表示するリスト
+            final listTiles = List<Widget>.generate(docs.length, (index) {
+              final data = docs[index].data() as Map<String, dynamic>;
+
+              final title = data['title'] as String? ?? 'No Title';
+              final description = data['description'] as String? ?? '';
+              final priority = data['priority'] as int? ?? 0;
+              final requiredTime = data['requiredTime'] as int? ?? 0;
+
+              // Timestamp -> DateTime
+              DateTime? deadlineDate;
+              final deadline = data['deadline'];
+              if (deadline is Timestamp) {
+                deadlineDate = deadline.toDate();
+              }
+
+              DateTime? createdDate;
+              final createdAt = data['createdAt'];
+              if (createdAt is Timestamp) {
+                createdDate = createdAt.toDate();
+              }
+
+              return ListTile(
+                title: Text(title),
+                subtitle: Text(
+                  '優先度: $priority\n'
+                      '必要な時間: $requiredTime 時間\n'
+                      '締め切り: ${deadlineDate?.toLocal() ?? '-'}\n'
+                      '作成日: ${createdDate?.toLocal() ?? '-'}\n'
+                      '$description',
+                ),
+                onTap: () {
+                  // タップ時の処理など
+                },
+              );
+            });
+
+            // 画面下にボタンを配置したいので Column
+            return Column(
+              children: [
+                // タスクをリストで表示
+                Expanded(
+                  child: ListView(children: listTiles),
+                ),
+
+                // 「タスクを確定する」ボタン
+                // isTaskFixed が falseの場合だけ表示
+                if (!isTaskFixed)
+                  Padding(
+                    padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          // goal ドキュメントに taskFixed = true を書き込む
+                          await chatViewModel.updateTaskFixed(
+                            userId: userId,
+                            goalId: selectedGoalId,
+                            taskFixed: true,
+                          );
+                          // 書き込み完了後、自動的に goal ドキュメントが更新されるため
+                          // ここでのゴールスナップショットが再ビルドされ、isTaskFixed が true になってボタンが消える
+                        },
+                        child: const Text('タスクを確定する'),
+                      ),
+                    ),
+                  ),
+              ],
             );
           },
         );

--- a/frontend/flutter_app/lib/view/tasks_tab_widget.dart
+++ b/frontend/flutter_app/lib/view/tasks_tab_widget.dart
@@ -120,11 +120,11 @@ class TaskTabWidget extends ConsumerWidget {
                       child: ElevatedButton(
                         onPressed: () async {
                           // goal ドキュメントに taskFixed = true を書き込む
-                          // await chatViewModel.updateTaskFixed(
-                          //   userId: userId,
-                          //   goalId: selectedGoalId,
-                          //   taskFixed: true,
-                          // );
+                          await chatViewModel.updateTaskFixed(
+                            userId: userId,
+                            goalId: selectedGoalId,
+                            taskFixed: true,
+                          );
                           // 書き込み完了後、自動的に goal ドキュメントが更新されるため
                           // ここでのゴールスナップショットが再ビルドされ、isTaskFixed が true になってボタンが消える
                           String? token = authViewModel.accessToken;

--- a/frontend/flutter_app/lib/view/tasks_tab_widget.dart
+++ b/frontend/flutter_app/lib/view/tasks_tab_widget.dart
@@ -2,7 +2,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hackathon_test1/repository/task_repository.dart';
+import 'package:hackathon_test1/viewmodel/auth_viewmodel.dart';
 import 'package:hackathon_test1/viewmodel/chat_viewmodel.dart';
+import 'dart:convert';
 
 /// 2つ目のタブ用のサンプルウィジェット
 class TaskTabWidget extends ConsumerWidget {
@@ -17,6 +20,7 @@ class TaskTabWidget extends ConsumerWidget {
     }
 
     final chatViewModel = ref.watch(chatViewModelProvider);
+    final authViewModel = ref.watch(authViewModelProvider);
     final userId = user.uid;
     final selectedGoalId = chatViewModel.selectedGoalId;
 
@@ -116,13 +120,19 @@ class TaskTabWidget extends ConsumerWidget {
                       child: ElevatedButton(
                         onPressed: () async {
                           // goal ドキュメントに taskFixed = true を書き込む
-                          await chatViewModel.updateTaskFixed(
-                            userId: userId,
-                            goalId: selectedGoalId,
-                            taskFixed: true,
-                          );
+                          // await chatViewModel.updateTaskFixed(
+                          //   userId: userId,
+                          //   goalId: selectedGoalId,
+                          //   taskFixed: true,
+                          // );
                           // 書き込み完了後、自動的に goal ドキュメントが更新されるため
                           // ここでのゴールスナップショットが再ビルドされ、isTaskFixed が true になってボタンが消える
+                          String? token = authViewModel.accessToken;
+                          await TaskRepository.fetchTasksAndPost(
+                            authToken: token!,
+                            userId: userId,
+                            goalId: selectedGoalId,
+                          );
                         },
                         child: const Text('タスクを確定する'),
                       ),

--- a/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
@@ -11,6 +11,10 @@ final authViewModelProvider = ChangeNotifierProvider((ref) => AuthViewModel());
 
 class AuthViewModel extends ChangeNotifier {
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+  /// ここでGoogleのアクセストークンを保持する
+  String? _accessToken;
+  /// アクセストークンを外部から参照できるようGetterを用意
+  String? get accessToken => _accessToken;
 
   // 既存、メールアドレスとパスワードのサインアップ
   Future<void> signUp(UserCredentials credentials, BuildContext context) async {
@@ -61,52 +65,6 @@ class AuthViewModel extends ChangeNotifier {
     ],
   );
 
-  Future<void> googleSignIn(BuildContext context) async {
-    try {
-      // サインイン済みなら signInSilently を試行
-      final existingUser = await _googleSignIn.signInSilently();
-      if (existingUser != null) {
-        // すでにログイン済みなら、そのまま使う
-        print("Already signed in with Google: ${existingUser.email}");
-        // ここでトークンを取得し、バックエンド連携するなり Firebase Auth にリンクするなり
-        final auth = await existingUser.authentication;
-        final accessToken = auth.accessToken;
-        final idToken = auth.idToken;
-        print('AccessToken: $accessToken');
-        print('IDToken: $idToken');
-        // TODO: サーバーへ送信 or Firebase signInWithCredential など
-        Navigator.pushReplacementNamed(context, '/chat');
-        return;
-      }
-
-      // まだなら、Googleアカウント選択画面が出る
-      final account = await _googleSignIn.signIn();
-      if (account == null) {
-        // ユーザーがキャンセルした
-        print("Google sign in cancelled by user.");
-        return;
-      }
-
-      // 成功時の処理
-      print("Google sign in success: ${account.email}");
-      final auth = await account.authentication;
-      final accessToken = auth.accessToken;
-      final idToken = auth.idToken;
-      print('AccessToken: $accessToken');
-      print('IDToken: $idToken');
-      Navigator.pushReplacementNamed(context, '/chat');
-
-      // TODO: ここでサーバーにトークンを渡す or Firebaseと連携など
-      // 例: Firebaseに連携する場合 => signInWithCredential(GoogleAuthProvider.credential(idToken: idToken))
-      // 例: 独自バックエンドの場合 => POST /google_auth でサーバーサイド検証
-    } catch (e) {
-      print("Google sign in failed: $e");
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Google SignIn Failed: $e")),
-      );
-    }
-  }
-
   // Googleサインアウト（必要であれば）
   Future<void> googleSignOut(BuildContext context) async {
     await _googleSignIn.signOut();
@@ -131,6 +89,7 @@ class AuthViewModel extends ChangeNotifier {
           idToken: googleAuth.idToken,
         );
         print("AccessToken : ${googleAuth.accessToken}");
+        _accessToken = googleAuth.accessToken;
         // ここで FirebaseAuth にサインイン
         await FirebaseAuth.instance.signInWithCredential(credential);
 

--- a/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
@@ -57,6 +57,7 @@ class AuthViewModel extends ChangeNotifier {
     scopes: [
       'email',
       'profile',
+      'https://www.googleapis.com/auth/tasks',
     ],
   );
 
@@ -129,6 +130,7 @@ class AuthViewModel extends ChangeNotifier {
           accessToken: googleAuth.accessToken,
           idToken: googleAuth.idToken,
         );
+        print("AccessToken : ${googleAuth.accessToken}");
         // ここで FirebaseAuth にサインイン
         await FirebaseAuth.instance.signInWithCredential(credential);
 

--- a/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/auth_viewmodel.dart
@@ -88,13 +88,9 @@ class AuthViewModel extends ChangeNotifier {
           accessToken: googleAuth.accessToken,
           idToken: googleAuth.idToken,
         );
-        print("AccessToken : ${googleAuth.accessToken}");
         _accessToken = googleAuth.accessToken;
         // ここで FirebaseAuth にサインイン
         await FirebaseAuth.instance.signInWithCredential(credential);
-
-        // これで FirebaseAuth.instance.currentUser が有効になる
-        print("FirebaseAuth signIn success: ${FirebaseAuth.instance.currentUser?.uid}");
       } catch (e) {
         print("Google sign in error: $e");
       }

--- a/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
+++ b/frontend/flutter_app/lib/viewmodel/chat_viewmodel.dart
@@ -136,4 +136,66 @@ class ChatViewModel extends ChangeNotifier {
       SnackbarHelper.show(context, 'Firestore 書き込みエラー: $e');
     }
   }
+
+  Stream<DocumentSnapshot> getGoalDocStream(String userId, String goalId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('goals')
+        .doc(goalId)
+        .snapshots();
+  }
+
+  Future<void> updateTaskFixed({
+    required String userId,
+    required String goalId,
+    required bool taskFixed,
+  }) async {
+    try {
+      await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('goals')
+          .doc(goalId)
+          .update({
+        'taskFixed': taskFixed,
+      });
+    } catch (e) {
+      debugPrint('Firestore 書き込みエラー: $e');
+    }
+  }
+
+  Future<bool?> getTaskFixed({
+    required String userId,
+    required String goalId,
+  }) async {
+    try {
+      final docSnapshot = await _firestore
+          .collection('users')
+          .doc(userId)
+          .collection('goals')
+          .doc(goalId)
+          .get();
+
+      if (!docSnapshot.exists) {
+        // ドキュメント自体が存在しない場合は null を返す
+        return null;
+      }
+
+      final data = docSnapshot.data();
+      if (data == null) {
+        // データがない場合
+        return null;
+      }
+
+      // taskFixed フィールドを bool? として取り出す
+      final taskFixed = data['taskFixed'] as bool?;
+      return taskFixed; // (true, false, あるいは null)
+    } catch (e) {
+      debugPrint('Firestore 読み込みエラー: $e');
+      // 呼び出し元で扱いやすいように null を返す
+      return null;
+    }
+  }
+
 }


### PR DESCRIPTION
注意：マージしないとバックエンドが動かないため、動作確認はマージ後になります

# 概要
- タスク画面の下部に「タスクを確定する」ボタンを追加

<img width="433" alt="image" src="https://github.com/user-attachments/assets/03ee9916-22d0-4143-8ca8-c386b2cdcebd" />

- これを押すとGoogleカレンダーにTODOがぶっこまれる
- 
<img width="431" alt="image" src="https://github.com/user-attachments/assets/67669f1f-d011-4355-8c8c-804a9ca43656" />
